### PR TITLE
[refactor] Diary 앱 리팩토링

### DIFF
--- a/center/serializers.py
+++ b/center/serializers.py
@@ -1,28 +1,42 @@
 from rest_framework import serializers, status
 
 
+def positive_validator(value):
+    if value < 0:
+        raise serializers.ValidationError(f'{value} 이 음수입니다.')
+
+
 class GetAroundCenterRequest(serializers.Serializer):
     # 위도
-    lat = serializers.FloatField(help_text='사용자 위도')
+    lat = serializers.FloatField(help_text='사용자 위도', validators=[positive_validator])
     # 경도
-    lon = serializers.FloatField(help_text='사용자 경도')
+    lon = serializers.FloatField(help_text='사용자 경도', validators=[positive_validator])
     # 반경 (km)
-    radius = serializers.FloatField(help_text='반경 (km) 거리안 치매센터 조회')
+    radius = serializers.FloatField(help_text='반경 (km) 거리안 치매센터 조회', validators=[positive_validator])
 
-    def is_valid(self, *, raise_exception=False):
-        super_valid = super().is_valid()
-        # 유효하지 않다면 False, 400 반환
-        if not super_valid:
-            return False, status.HTTP_400_BAD_REQUEST
 
-        # 위도 , 경도가 양수인지 확인
-        if self.data['lat'] < 0 or self.data['lon'] < 0:
-            self._errors['lat'] = [f'lat: {self.data.get("lat")} 또는 lon: {self.data.get("lon")} 이 음수입니다.']
-            return False, status.HTTP_400_BAD_REQUEST
-
-        # 반경이 양수인지 확인
-        if self.data['radius'] < 0:
-            self._errors['radius'] = [f'radius: {self.data.get("radius")} 이 음수입니다.']
-            return False, status.HTTP_400_BAD_REQUEST
-
-        return True, status.HTTP_200_OK
+class CenterResponse(serializers.Serializer):
+    치매센터명 = serializers.CharField()
+    치매센터유형 = serializers.CharField()
+    소재지도로명주소 = serializers.CharField()
+    소재지지번주소 = serializers.CharField()
+    위도 = serializers.CharField()
+    경도 = serializers.CharField()
+    설립연월 = serializers.CharField()
+    건축물면적 = serializers.CharField()
+    부대시설정보 = serializers.CharField()
+    의사인원수 = serializers.CharField()
+    간호사인원수 = serializers.CharField()
+    사회복지사인원수 = serializers.CharField()
+    기타인원현황 = serializers.CharField()
+    운영기관명 = serializers.CharField()
+    운영기관대표자명 = serializers.CharField()
+    운영기관전화번호 = serializers.CharField()
+    운영위탁일자 = serializers.CharField()
+    주요치매관리프로그램소개 = serializers.CharField()
+    관리기관전화번호 = serializers.CharField()
+    관리기관명 = serializers.CharField()
+    데이터기준일자 = serializers.CharField()
+    제공기관코드 = serializers.CharField()
+    제공기관명 = serializers.CharField()
+    나와의거리 = serializers.FloatField()

--- a/center/views.py
+++ b/center/views.py
@@ -6,22 +6,22 @@ from rest_framework import status
 from rest_framework.views import APIView
 
 from center.center_data import centers
-from center.serializers import GetAroundCenterRequest
-from config.basemodel import ApiResponse
+from center.serializers import GetAroundCenterRequest, CenterResponse
+from config.basemodel import ApiResponse, validator
+from config.settings import REQUEST_QUERY
 
 
 class GetAroundCenter(APIView):
     @transaction.atomic
-    @swagger_auto_schema(operation_description="주변 치매 센터 조회", query_serializer=GetAroundCenterRequest,
-                         responses={"200": '성공'})
+    @swagger_auto_schema(
+        operation_id="주변 치매 센터 조회",
+        operation_description="주변 치매 센터 조회",
+        query_serializer=GetAroundCenterRequest(),
+        responses={status.HTTP_200_OK: ApiResponse.schema(CenterResponse, many=True)}
+    )
+    @validator(request_type=REQUEST_QUERY, request_serializer=GetAroundCenterRequest, return_key='query')
     def get(self, request):
-        requestSerial = GetAroundCenterRequest(data=request.query_params)
-
-        isValid, response_status = requestSerial.is_valid()
-        # 유효성 검사 통과하지 못한 경우
-        if not isValid:
-            return ApiResponse.on_fail(requestSerial.errors, response_status=response_status)
-
+        requestSerial = request.query
         request = requestSerial.validated_data
 
         # 위도 경도 가져오기

--- a/config/basemodel.py
+++ b/config/basemodel.py
@@ -28,7 +28,7 @@ class ApiResponse(serializers.Serializer):
 
     @staticmethod
     def on_success(result=None, message="OK", response_status=status.HTTP_200_OK):
-        if not result:
+        if result is None:
             return JsonResponse({'isSuccess': True, "message": message}, status=response_status)
         return JsonResponse({'isSuccess': True, "message": message, 'result': result}, status=response_status)
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -16,6 +16,8 @@ schema_view = get_schema_view(
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('diary', include('diary.urls')),
+    path('keyword', include('diary.keyword_urls')),
+    path('quiz', include('diary.quiz_urls')),
     path('users', include('users.urls')),
     path('image', include('image.urls')),
     path('center', include('center.urls')),

--- a/diary/graph_serializer.py
+++ b/diary/graph_serializer.py
@@ -1,0 +1,41 @@
+from rest_framework import serializers
+
+
+class UserNode(serializers.Serializer):
+    id = serializers.IntegerField()
+    user_id = serializers.IntegerField()
+    label = serializers.CharField(help_text='User')
+    text = serializers.CharField()
+
+
+class DiaryNode(serializers.Serializer):
+    id = serializers.IntegerField()
+    diary_id = serializers.IntegerField()
+    label = serializers.CharField(help_text='Diary')
+    text = serializers.CharField()
+
+
+class KeywordNode(serializers.Serializer):
+    id = serializers.IntegerField()
+    label = serializers.CharField(help_text='Keyword')
+    text = serializers.CharField()
+    weight = serializers.FloatField()
+
+
+class Property(serializers.Serializer):
+    tfidf = serializers.FloatField()
+
+
+class Relationships(serializers.Serializer):
+    properties = Property()
+    type = serializers.CharField(help_text='INCLUDE|CONNECTED|WROTE')
+    startNode = serializers.IntegerField()
+    endNode = serializers.IntegerField()
+
+
+class GraphDataSerializer(serializers.Serializer):
+    User = UserNode()
+    Diary = DiaryNode()
+    # [UserNode(), DiaryNode(), KeywordNode()]
+    nodes = serializers.ListField(child=serializers.DictField(help_text='UserNode|DiaryNode|KeywordNode'))
+    relationships = Relationships()

--- a/diary/keyword_urls.py
+++ b/diary/keyword_urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+
+from .keyword_views import *
+
+urlpatterns = [
+    path('/diray/<int:diaryId>', GetKeywordView.as_view()),
+    path('/<int:keywordId>/image', KeywordImgSaveView.as_view()),
+]

--- a/diary/keyword_views.py
+++ b/diary/keyword_views.py
@@ -1,0 +1,55 @@
+from django.db import transaction
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework.utils.serializer_helpers import ReturnDict
+from rest_framework.views import APIView
+
+from config.basemodel import ApiResponse, validator
+from config.settings import REQUEST_BODY, REQUEST_PATH
+from diary.serializers import *
+
+
+class GetKeywordView(APIView):
+    @transaction.atomic
+    @swagger_auto_schema(
+        operation_id="일기별 키워드 조회",
+        operation_description="일기별 키워드 조회",
+        response={status.HTTP_200_OK: ApiResponse.schema(KeywordResultSerializer, many=True)}
+    )
+    @validator(request_type=REQUEST_PATH, request_serializer=GetDiaryRequest)
+    def get(self, request, diaryId: int):
+        # Diary 가져오기
+        diary = Diary.objects.get(id=diaryId)
+
+        # Diary 연관된 모든 Keyword 가져오기
+        findKeywords = Keywords.objects.filter(diary=diary)
+
+        return ApiResponse.on_success(
+            result=KeywordResultSerializer(findKeywords, many=True).data,
+            response_status=status.HTTP_200_OK
+        )
+
+
+class KeywordImgSaveView(APIView):
+    @transaction.atomic
+    @swagger_auto_schema(
+        operation_id="키워드별 이미지 저장",
+        operation_description="키워드별 이미지 저장",
+        request_body=ImageUrlRequest,
+        responses={status.HTTP_201_CREATED: ApiResponse.schema(KeywordSerializer, description='저장 성공')}
+    )
+    @validator(request_type=REQUEST_PATH, request_serializer=GetDiaryRequest, return_key='dump')
+    @validator(request_type=REQUEST_BODY, request_serializer=ImageUrlRequest, return_key='serializer')
+    def post(self, request, keywordId: int):
+        request: ReturnDict = request.serializer.validated_data
+
+        # keyword 객체 가져오기
+        keyword = Keywords.objects.get(id=keywordId)
+
+        # imgUrl 저장
+        keyword.imgUrl = request.get('imgUrl')
+        keyword.save()
+
+        return ApiResponse.on_success(
+            result=KeywordSerializer(keyword).data,
+            response_status=status.HTTP_201_CREATED
+        )

--- a/diary/models.py
+++ b/diary/models.py
@@ -1,6 +1,8 @@
 from django.db import models
 
 from config.basemodel import BaseModel
+from diary.graph import GraphDB
+from diary.text_rank_modules.textrank import TextRank, make_quiz
 
 
 class Diary(BaseModel):
@@ -19,11 +21,43 @@ class Diary(BaseModel):
     def __str__(self):
         return self.title
 
+    def delete(self, using=None, keep_parents=False):
+        conn = GraphDB()
+        conn.delete_diary(user_id=self.user.id, diary_id=self.id)
+        return self
+
+    @staticmethod
+    def create(user=None, title=None, content=None, createDate=None, img_url=None):
+        newDiary = Diary.objects.create(user=user, title=title, content=content, createDate=createDate, imgUrl=img_url)
+
+        conn = GraphDB()
+        memory = TextRank(content=content)
+
+        # GraphDB에 추가
+        conn.create_and_link_nodes(
+            user_id=newDiary.user.id, diary_id=newDiary.id,
+            words_graph=memory.words_graph,
+            words_dict=memory.words_dict,
+            weights_dict=memory.weights_dict
+        )
+
+        # 키워드 추출 후 가중치가 높은 키워드 5개로 퀴즈 생성
+        question, keyword = make_quiz(memory, keyword_size=5)
+
+        # 각 키워드별로 Question 생성
+        for q, k in zip(question, keyword):
+            newKeyword = Keywords.objects.create(keyword=k, diary=newDiary)
+            Questions.objects.create(question=q, keyword=newKeyword)
+
+        return newDiary
+
+
 class Keywords(BaseModel):
     keyword = models.CharField(max_length=100)
     imgUrl = models.TextField(null=True)
 
     diary = models.ForeignKey('diary.Diary', related_name='keywords', on_delete=models.CASCADE)
+
 
 class Questions(BaseModel):
     question = models.TextField()

--- a/diary/quiz_urls.py
+++ b/diary/quiz_urls.py
@@ -2,5 +2,5 @@ from django.urls import path
 from .views import *
 
 urlpatterns = [
-    path('', ImageView.as_view()),
+    path('', GetQuizView.as_view()),
 ]

--- a/diary/urls.py
+++ b/diary/urls.py
@@ -1,17 +1,12 @@
 from django.urls import path
+
 from .views import *
 
 urlpatterns = [
-    path('/write', WriteView.as_view()),
-    path('/list', GetDiaryByUserView.as_view()),
-    path('/quiz', GetQuizView.as_view()),
-    path('/update', UpdateView.as_view()),
-    path('/search', GetDiaryByDateView.as_view()),
-    path('/delete', DeleteDiaryView.as_view()),
-    path('/graph', GetNodeData.as_view()),
-    path('/keywordImg', KeywordImgSaveView.as_view()),
-    path('/diaryImg', DiaryImgSaveView.as_view()),
-    path('/pagingImg', KeywordImgPagingView.as_view()),
+    path('', DiaryCreateView.as_view()),
+    path('/<int:diaryId>/image', DiaryImgSaveView.as_view()),
+    path('/<int:diaryId>', DiaryCRUDView.as_view()),
+    path('/<int:diaryId>/graph', GetNodeData.as_view()),
+    path('/user/<int:userId>', GetDiaryByUserView.as_view()),
     path('/checkanswer', CheckAnswerView.as_view()),
-    path('/keyword', GetKeywordView.as_view())
 ]

--- a/diary/validator.py
+++ b/diary/validator.py
@@ -1,0 +1,18 @@
+from rest_framework import serializers
+
+from diary.models import Diary, Keywords
+
+
+def exist_diary_id(diary_id):
+    if not Diary.objects.filter(id=diary_id).exists():
+        raise serializers.ValidationError(f'diaryId: {diary_id} 가 존재하지 않습니다.')
+
+
+def not_exist_diary_date(user_id, date):
+    if Diary.objects.filter(user_id=user_id, createDate=date).exists():
+        raise serializers.ValidationError(f'이미 작성된 일기가 있습니다.')
+
+
+def exist_keyword_id(keyword_id):
+    if not Keywords.objects.filter(id=keyword_id).exists():
+        raise serializers.ValidationError(f'keywordId: {keyword_id} 가 존재하지 않습니다.')

--- a/diary/views.py
+++ b/diary/views.py
@@ -13,7 +13,12 @@ from .graph import GraphDB
 
 class WriteView(APIView):
     @transaction.atomic
-    @swagger_auto_schema(operation_description="일기 작성", request_body=WriteRequest, responses={"201": '작성 성공'})
+    @swagger_auto_schema(
+        operation_id="일기 작성",
+        operation_description="일기 작성",
+        request_body=WriteRequest,
+        responses={status.HTTP_200_OK: ApiResponse.schema(DiaryResultResponse)}
+    )
     def post(self, request):
         requestSerial = WriteRequest(data=request.data)
 
@@ -61,7 +66,12 @@ class WriteView(APIView):
 
 class UpdateView(APIView):
     @transaction.atomic
-    @swagger_auto_schema(operation_description="일기 수정", request_body=UpdateRequest, responses={"201": '작성 성공'})
+    @swagger_auto_schema(
+        operation_id="일기 수정",
+        operation_description="일기 수정",
+        request_body=UpdateRequest,
+        responses={status.HTTP_200_OK: ApiResponse.schema(DiaryResultResponse, description='수정 성공')}
+    )
     def patch(self, request):
         requestSerial = UpdateRequest(data=request.data)
 
@@ -122,8 +132,12 @@ class UpdateView(APIView):
 
 class GetDiaryByUserView(APIView):
     @transaction.atomic
-    @swagger_auto_schema(operation_description="유저의 일기 조회", query_serializer=GetUserRequest,
-                         response={"200": DiaryResultResponse})
+    @swagger_auto_schema(
+        operation_id="유저의 일기 조회",
+        operation_description="유저의 일기 조회",
+        query_serializer=GetUserRequest(),
+        responses={status.HTTP_200_OK: ApiResponse.schema(DiaryResultResponse, many=True)}
+    )
     def get(self, request):
         requestSerial = GetUserRequest(data=request.query_params)
 
@@ -151,8 +165,12 @@ class GetDiaryByUserView(APIView):
 
 class GetQuizView(APIView):
     @transaction.atomic
-    @swagger_auto_schema(operation_description="일기회상 퀴즈", query_serializer=GetDiaryRequest,
-                         responses={"200": "퀴즈"})
+    @swagger_auto_schema(
+        operation_id="일기회상 퀴즈",
+        operation_description="일기회상 퀴즈",
+        query_serializer=GetDiaryRequest(),
+        # responses={status.HTTP_200_OK: ApiResponse.schema(QuizResultResponse, description="퀴즈")}
+    )
     def get(self, request):
         requestSerial = GetDiaryRequest(data=request.query_params)
 
@@ -188,8 +206,12 @@ class GetQuizView(APIView):
 
 class CheckAnswerView(APIView):
     @transaction.atomic
-    @swagger_auto_schema(operation_description="일기회상 답안 확인", request_body=AnswerListRequest,
-                         responses={"200": "답안 채점"})
+    @swagger_auto_schema(
+        operation_id="일기회상 답안 확인",
+        operation_description="일기회상 답안 확인",
+        request_body=AnswerListRequest,
+        # responses={status.HTTP_200_OK: ApiResponse.schema(AnswerResultResponse, description="결과")}
+    )
     def post(self, request):
         requestSerial = AnswerListRequest(data=request.data)
 
@@ -200,7 +222,7 @@ class CheckAnswerView(APIView):
             return ApiResponse.on_fail(requestSerial.errors, response_status=response_status)
 
         request = requestSerial.validated_data
-        
+
         answers = []
         result = []
         score = 0
@@ -231,10 +253,15 @@ class CheckAnswerView(APIView):
             response_status=status.HTTP_200_OK
         )
 
+
 class GetDiaryByDateView(APIView):
     @transaction.atomic
-    @swagger_auto_schema(operation_description="날짜로 일기 검색", query_serializer=GetDiaryByDateRequest,
-                         responses={"200": "일기"})
+    @swagger_auto_schema(
+        operation_id="날짜로 일기 검색",
+        operation_description="날짜로 일기 검색",
+        query_serializer=GetDiaryByDateRequest(),
+        responses={status.HTTP_200_OK: ApiResponse.schema(DiaryResultResponse, description="일기")}
+    )
     def get(self, request):
         requestSerial = GetDiaryByDateRequest(data=request.query_params)
 
@@ -258,8 +285,12 @@ class GetDiaryByDateView(APIView):
 
 class DeleteDiaryView(APIView):
     @transaction.atomic
-    @swagger_auto_schema(operation_description="일기 삭제", request_body=DeleteDiaryRequest,
-                         responses={200: '삭제 완료'})
+    @swagger_auto_schema(
+        operation_id="일기 삭제",
+        operation_description="일기 삭제",
+        request_body=DeleteDiaryRequest,
+        responses={status.HTTP_200_OK: ApiResponse.schema(DiaryResultResponse, description='삭제 완료')}
+    )
     def delete(self, request):
         requestSerial = DeleteDiaryRequest(data=request.data)
 
@@ -284,9 +315,12 @@ class DeleteDiaryView(APIView):
 
 class GetNodeData(APIView):
     @transaction.atomic
-    @swagger_auto_schema(operation_description="노드데이터 가져오기", query_serializer=DeleteDiaryRequest)
+    @swagger_auto_schema(
+        operation_id="그래프 데이터 가져오기",
+        operation_description="노드데이터 가져오기",
+        query_serializer=DeleteDiaryRequest()
+    )
     def get(self, request):
-
         requestSerial = DeleteDiaryRequest(data=request.query_params)
 
         isValid, response_status = requestSerial.is_valid()
@@ -313,7 +347,12 @@ class GetNodeData(APIView):
 
 class KeywordImgSaveView(APIView):
     @transaction.atomic
-    @swagger_auto_schema(operation_description="키워드별 이미지 저장", request_body=KeyWordImgSaveRequest, responses={"201": '저장 성공'})
+    @swagger_auto_schema(
+        operation_id="키워드별 이미지 저장",
+        operation_description="키워드별 이미지 저장",
+        request_body=KeyWordImgSaveRequest,
+        responses={status.HTTP_201_CREATED: ApiResponse.schema(KeywordSerializer, description='저장 성공')}
+    )
     def post(self, request):
         requestSerial = KeyWordImgSaveRequest(data=request.data)
 
@@ -339,7 +378,12 @@ class KeywordImgSaveView(APIView):
 
 class DiaryImgSaveView(APIView):
     @transaction.atomic
-    @swagger_auto_schema(operation_description="일기 이미지 저장", request_body=DiaryImgSaveRequest, responses={"201": '저장 성공'})
+    @swagger_auto_schema(
+        operation_id="일기 이미지 저장",
+        operation_description="일기 이미지 저장",
+        request_body=DiaryImgSaveRequest,
+        responses={status.HTTP_201_CREATED: ApiResponse.schema(DiaryResultResponse, description='저장 성공')}
+    )
     def post(self, request):
         requestSerial = DiaryImgSaveRequest(data=request.data)
 
@@ -361,11 +405,16 @@ class DiaryImgSaveView(APIView):
             result=DiaryResultResponse(diary).data,
             response_status=status.HTTP_201_CREATED
         )
-    
+
 
 class KeywordImgPagingView(APIView):
     @transaction.atomic
-    @swagger_auto_schema(operation_description="키워드별 사진 페이징", query_serializer=FindKeywordImgRequest)
+    @swagger_auto_schema(
+        operation_id="키워드별 사진 페이징",
+        operation_description="키워드별 사진 페이징",
+        query_serializer=FindKeywordImgRequest(),
+        # responses=
+    )
     def get(self, request):
         requestSerial = FindKeywordImgRequest(data=request.query_params)
 
@@ -381,7 +430,7 @@ class KeywordImgPagingView(APIView):
         # 필터링된 객체가 없을 경우 404 반환
         if not keywordObjects:
             return ApiResponse.on_fail({"message": "아직 그려진 그림이 없습니다."}, status.HTTP_404_NOT_FOUND)
-        
+
         # 최신순으로 정렬
         keywordObjects = keywordObjects.order_by('-updated_at')
 
@@ -421,12 +470,16 @@ class KeywordImgPagingView(APIView):
             result=result,
             response_status=status.HTTP_201_CREATED
         )
-    
+
 
 class GetKeywordView(APIView):
     @transaction.atomic
-    @swagger_auto_schema(operation_description="일기별 키워드 조회", query_serializer=GetDiaryRequest,
-                         response={"200": KeywordResultSerializer})
+    @swagger_auto_schema(
+        operation_id="일기별 키워드 조회",
+        operation_description="일기별 키워드 조회",
+        query_serializer=GetDiaryRequest(),
+        response={status.HTTP_200_OK: ApiResponse.schema(KeywordResultSerializer, many=True)}
+    )
     def get(self, request):
         requestSerial = GetDiaryRequest(data=request.query_params)
 

--- a/image/serializer.py
+++ b/image/serializer.py
@@ -11,3 +11,6 @@ class ImageRequest(serializers.Serializer):
 
         return True, status.HTTP_200_OK
 
+
+class ImageResponse(serializers.Serializer):
+    imageUrl = serializers.CharField()

--- a/image/views.py
+++ b/image/views.py
@@ -1,16 +1,17 @@
 import os
 from datetime import datetime
 
+from django.core.paginator import Paginator, PageNotAnInteger, EmptyPage
 from django.db import transaction
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
-from rest_framework import status
 from rest_framework.parsers import MultiPartParser
 from rest_framework.views import APIView
 
 from config.basemodel import ApiResponse
+from diary.serializers import *
 from image.s3_modules.s3_handler import upload_file_to_s3
-from image.serializer import ImageRequest
+from image.serializer import ImageRequest, ImageResponse
 
 
 # Create your views here.
@@ -34,7 +35,7 @@ class ImageView(APIView):
             #
         ],
         responses={
-            status.HTTP_200_OK: '업로드 성공'
+            status.HTTP_200_OK: ApiResponse.schema(ImageResponse, description='이미지 업로드 성공')
         },
     )
     def post(self, request):
@@ -61,4 +62,67 @@ class ImageView(APIView):
                 'imageUrl': url
             },
             response_status=status.HTTP_200_OK
+        )
+
+    @transaction.atomic
+    @swagger_auto_schema(
+        operation_id="키워드별 사진 페이징",
+        operation_description="키워드별 사진 페이징",
+        query_serializer=FindKeywordImgRequest(),
+        # responses=
+    )
+    def get(self, request):
+        requestSerial = FindKeywordImgRequest(data=request.query_params)
+
+        isValid, response_status = requestSerial.is_valid()
+        # 유효성 검사 통과하지 못한 경우
+        if not isValid:
+            return ApiResponse.on_fail(requestSerial.errors, response_status=response_status)
+
+        request = requestSerial.validated_data
+
+        keywordObjects = Keywords.objects.filter(keyword=request.get('keyword'))
+
+        # 필터링된 객체가 없을 경우 404 반환
+        if not keywordObjects:
+            return ApiResponse.on_fail({"message": "아직 그려진 그림이 없습니다."}, status.HTTP_404_NOT_FOUND)
+
+        # 최신순으로 정렬
+        keywordObjects = keywordObjects.order_by('-updated_at')
+
+        # imgUrl 필드만 가져와서 리스트로 변환하지 않고 쿼리셋으로 페이지네이션
+        keywordImgUrls = keywordObjects.values_list('imgUrl', flat=True)
+        requestPage = request.get('page')
+        pageSize = request.get('pageSize')
+
+        paginator = Paginator(keywordImgUrls, pageSize)
+
+        try:
+            pageObj = paginator.page(requestPage)
+        except PageNotAnInteger:
+            firstPage = 1
+            pageObj = paginator.page(firstPage)
+        except EmptyPage:
+            lastPage = paginator.num_pages
+            pageObj = paginator.page(lastPage)
+
+        result = []
+
+        # JSON 응답 생성
+        result.append({
+            "isSuccess": True,
+            "results": {
+                "imgUrls": list(pageObj),
+                "totalDataSize": paginator.count,
+                "totalPage": paginator.num_pages,
+                "hasNext": pageObj.has_next(),
+                "hasPrevious": pageObj.has_previous(),
+                "currentPage": pageObj.number,
+                "dataSize": pageSize
+            }
+        })
+
+        return ApiResponse.on_success(
+            result=result,
+            response_status=status.HTTP_201_CREATED
         )

--- a/users/views.py
+++ b/users/views.py
@@ -18,6 +18,10 @@ class UserListView(APIView):
         operation_description="`개발용` \n"
                               "회원 목록 출력",
         security=[],
+        responses={
+            status.HTTP_200_OK:
+                ApiResponse.schema(UserSerializer, many=True)
+        }
     )
     def get(self, request: Request) -> HttpResponse:
         findUsers = User.objects.all()
@@ -29,7 +33,9 @@ class UserListView(APIView):
 
 class UserView(APIView):
     @transaction.atomic
-    @swagger_auto_schema(operation_id="유저 조회", responses={200: '성공'}, security=[{'AccessToken': []}])
+    @swagger_auto_schema(operation_id="유저 조회",
+                         responses={status.HTTP_200_OK: ApiResponse.schema(UserSerializer, description="유저 조회")},
+                         security=[{'AccessToken': []}])
     @token_permission_validator(where_is_userId=REQUEST_PATH)
     @validator(request_type=REQUEST_PATH, request_serializer=UserIdReqeust, return_key='serializer')
     def get(self, request, userId: int):
@@ -39,8 +45,11 @@ class UserView(APIView):
         )
 
     @transaction.atomic
-    @swagger_auto_schema(operation_id="유저 수정", request_body=UserUpdateRequest, responses={200: '성공'}
-        , security=[{'AccessToken': []}])
+    @swagger_auto_schema(
+        operation_id="유저 수정", request_body=UserUpdateRequest,
+        responses={status.HTTP_200_OK: ApiResponse.schema(UserSerializer)},
+        security=[{'AccessToken': []}]
+    )
     @token_permission_validator(where_is_userId=REQUEST_PATH)
     @validator(request_serializer=UserIdReqeust, request_type=REQUEST_PATH, return_key='serializer')
     @validator(request_serializer=UserUpdateRequest, request_type=REQUEST_BODY, return_key='serializer')
@@ -52,14 +61,17 @@ class UserView(APIView):
         )
 
     @transaction.atomic
-    @swagger_auto_schema(operation_id="유저 삭제", responses={200: '삭제 완료'},
-                         security=[{'AccessToken': []}])
+    @swagger_auto_schema(
+        operation_id="유저 삭제",
+        responses={status.HTTP_200_OK: ApiResponse.schema(ApiResponse)},
+        security=[{'AccessToken': []}]
+    )
     @token_permission_validator(where_is_userId=REQUEST_PATH)
     @validator(request_serializer=UserIdReqeust, request_type=REQUEST_PATH, return_key='serializer')
     def delete(self, request, userId: int):
         User.objects.get(id=userId).delete()
         return ApiResponse.on_success(
-            result="삭제 완료"
+            message="삭제 완료"
         )
 
 
@@ -70,7 +82,7 @@ class SignupView(APIView):
         operation_id="회원 가입",
         operation_description="회원 가입",
         request_body=UserCreateRequest,
-        responses={200: "회원 가입 성공"},
+        responses={status.HTTP_200_OK: ApiResponse.schema(UserSafeSerializer, description="회원가입 성공")},
         security=[],
     )
     @validator(request_serializer=UserCreateRequest, request_type=REQUEST_BODY, return_key='serializer')
@@ -84,8 +96,12 @@ class SignupView(APIView):
 
 class LoginView(APIView):
     @transaction.atomic
-    @swagger_auto_schema(operation_id="로그인", request_body=LoginRequest,
-                         security=[])
+    @swagger_auto_schema(
+        operation_id="로그인",
+        request_body=LoginRequest,
+        responses={status.HTTP_200_OK: ApiResponse.schema(serializer_class=LoginResponse, description="로그인 성공")},
+        security=[]
+    )
     @validator(request_serializer=LoginRequest, request_type=REQUEST_BODY, return_key="serializer")
     def post(self, request):
         findUser = User.objects.get(
@@ -116,8 +132,11 @@ class LoginView(APIView):
 
 class CheckNicknameView(APIView):
     @transaction.atomic
-    @swagger_auto_schema(operation_id="닉네임 중복 확인", request_body=DuplicateNicknameRequest,
-                         responses={200: '닉네임 사용 가능'}, security=[])
+    @swagger_auto_schema(
+        operation_id="닉네임 중복 확인", request_body=DuplicateNicknameRequest,
+        responses={status.HTTP_200_OK: ApiResponse.schema(ApiResponse, description="사용가능한 닉네임")},
+        security=[]
+    )
     @validator(request_serializer=DuplicateNicknameRequest)
     def post(self, request):
         return ApiResponse.on_success(
@@ -128,7 +147,11 @@ class CheckNicknameView(APIView):
 
 class AutoLoginView(APIView):
     @transaction.atomic
-    @swagger_auto_schema(operation_id="자동 로그인", responses={200: '자동 로그인 성공'})
+    @swagger_auto_schema(
+        operation_id="자동 로그인",
+        responses={
+            status.HTTP_200_OK: ApiResponse.schema(LoginResponse, description="자동 로그인 성공")}
+    )
     @token_permission_validator(where_is_userId=REQUEST_PATH)
     @validator(request_serializer=TokenSerializer, request_type=REQUEST_HEADER, return_key="token")
     @validator(request_serializer=AutoLoginRequest, request_type=REQUEST_PATH)

--- a/wait-for-services.sh
+++ b/wait-for-services.sh
@@ -2,12 +2,12 @@
 
 # Wait for MySQL
 while ! nc -z mysql 3306; do
-  sleep 0.1
+  sleep 0.5
 done
 
 # Wait for Neo4j
 while ! nc -z neo4j 7687; do
-  sleep 0.1
+  sleep 0.5
 done
 
 # Now execute the main command


### PR DESCRIPTION
## PR type
- [x] Feature
- [x] Refactor

## 💻 작업사항

- ApiResponse.schema 메서드로 drf-yasg 의 schema 반환 코드 구현
- django 컨테이너의 mysql, neo4j 기다리는 시간 0.5초 간격으로 변경
- view들의 response, operation_id 추가
- diary view에서 사용되던 Serializer 들 validator을 이용한 리팩토링
- diary url 들 quiz, keyword, image 들로 분리
- validator, model의 update, create 메서드 등을 이용한 view 코드 리팩토링

# 바뀐 API URL
- 일기 작성 /diary/write -> /diary
- 일기 삭제 /diary/delete -> /diary/{diaryId}
- 일기 수정 /diary/update -> /diary/{diaryId}
- 일기 조회 (날짜 및 특정 유저의 모든일기) /diary/search, /diary/list -> /diary/user/{userId}
- 일기 그래프 데이터 조회 /diary/graph -> /diary/{diaryId}/graph
- 일기별 키워드 조회 /diary/keyword -> /diary/{diaryId}/keyword
- 일기 사진 변경 /diary/diaryImg -> /diary/{diaryId}/image
- 키워드 사진 변경 /diary/keywordImg -> /keyword/{keywordId}/image
- 일기 회상 퀴즈 /diary/quiz -> /quiz
- 키워드별 사진 페이징 /diary/pageingImg -> /image

