### PR TITLE
[fix] 문장의 동일 키워드 중 첫번째 키워드만 빈칸이 되도록 변경

### DIFF
--- a/diary/text_rank_modules/textrank.py
+++ b/diary/text_rank_modules/textrank.py
@@ -49,7 +49,7 @@ def make_quiz(text_rank: TextRank, keyword_size=3):
                 answer_keywords.append(word)
 
                 # 문장에서 키워드를 _로 대체
-                sentence = sentence.replace(word, "_" * len(word))
+                sentence = sentence.replace(word, "_" * len(word), 1)
 
                 # 퀴즈 문장 추가
                 quiz_sentences.append(sentence)


### PR DESCRIPTION
## PR type
- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Chore

## 💻 작업사항

- 문장에 동일 키워드가 여러개 있을 경우 모두 빈칸으로 바뀌었는데 첫번째로 나온 키워드만 빈칸이 되도록 수정

## 💡 작성한 이슈 외에 작업한 사항

- x

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
