### PR TITLE
feat/170 유저별 일기 페이징 api 구현

### DIFF
--- a/diary/serialziers/diary_response_serializers.py
+++ b/diary/serialziers/diary_response_serializers.py
@@ -1,5 +1,6 @@
 from django.db.models import QuerySet
 
+from config.paging_handler import PagingSerializer, get_paging_data
 from diary.serialziers.keyword_serializers import KeywordResponse
 from diary.validator import *
 from users.serializers.user_get_post_put_delete_serializers import *
@@ -59,3 +60,15 @@ class GetDiariesByUserAndDateResponse(serializers.Serializer):
             'user': UserSafeSerializer(user).data,
             'diaries': [GetDiaryPreviewResponse.to_json(diary) for diary in diaries]
         }
+
+
+class DiaryPagingResponse(PagingSerializer):
+    diaryList = serializers.ListField(child=DiaryResultResponse())
+
+    def __init__(self, *args, page=1, pageSize=1, object_list=None, **kwargs):
+        if object_list is None:
+            object_list = []
+
+        data = get_paging_data(page, pageSize, object_list, data_name="diaryList")
+
+        super().__init__(data, *args, **kwargs)

--- a/diary/serialziers/diray_request_serializers.py
+++ b/diary/serialziers/diray_request_serializers.py
@@ -1,4 +1,5 @@
 from config.sort_options import *
+from config.validator import positive_value
 from diary.validator import *
 from users.models import User
 from users.validator import exist_user_id
@@ -76,3 +77,9 @@ class DiaryUpdateRequest(serializers.Serializer):
             content=content,
             createDate=createDate
         )
+    
+
+class GetDiaryPagingRequset(serializers.Serializer):
+    userId = serializers.IntegerField(validators=[exist_user_id])
+    page = serializers.IntegerField(validators=[positive_value])
+    pageSize = serializers.IntegerField(validators=[positive_value])

--- a/diary/urls/diary_urls.py
+++ b/diary/urls/diary_urls.py
@@ -14,4 +14,5 @@ urlpatterns = [
     path('/checkanswer', CheckAnswerView.as_view()),
     path('/check', CheckDiaryEntriesView.as_view()),
     path('/list', GetDiaryByUserAndDateView.as_view()),
+    path('/user', GetDiaryPagingView.as_view()),
 ]


### PR DESCRIPTION
## PR type
- [ ] Bug fix
- [X] Feature
- [ ] Refactor
- [ ] Chore

## 💻 작업사항

- 유저별 일기 페이징 기능 구현

**API Docs**

Request
```
/diary/user?userId=2&page=1&pageSize=2
```

Response

totalDataSize : Integer (전체 데이터의 개수)
totalPage : Integer (전체 페이지 수)
hasNext : Boolean (다음 페이지 있는지 여부)
hasPrevious : Boolean (이전 페이지 있는지 여부)
currentPage : Integer (현재 페이지)
dataSize : Integer (페이지별 데이터 개수)
diaryList : [ diary : diaryInfo(*) ]

```json
{
  "isSuccess": true,
  "message": "OK",
  "result": {
    "totalDataSize": 8,
    "totalPage": 4,
    "hasNext": true,
    "hasPrevious": false,
    "currentPage": 1,
    "dataSize": 2,
    "diaryList": [
      {
        "diaryId": 1,
        "title": "string",
        "createDate": "2024-08-01",
        "content": "string",
        "imgUrl": null
      },
      {
        "diaryId": 2,
        "title": "string",
        "createDate": "2024-07-31",
        "content": "string",
        "imgUrl": null
      }
    ]
  }
```

## 💡 작성한 이슈 외에 작업한 사항

- X

## ✔️ check list

- [X] 작성한 이슈의 내용을 전부 적용했나요?
- [X] 리뷰어를 등록했나요?
